### PR TITLE
feat(products): implement CRUD endpoints for product management

### DIFF
--- a/src/main/java/com/example/ecommerce/DTO/ProductDTO.java
+++ b/src/main/java/com/example/ecommerce/DTO/ProductDTO.java
@@ -1,0 +1,13 @@
+package com.example.ecommerce.DTO;
+
+import lombok.Data;
+
+@Data
+public class ProductDTO {
+    private String name;
+    private Double price;
+    private String description;
+    private String category;
+    private String img;
+
+}

--- a/src/main/java/com/example/ecommerce/config/SecurityConfiguration.java
+++ b/src/main/java/com/example/ecommerce/config/SecurityConfiguration.java
@@ -36,6 +36,8 @@ public class SecurityConfiguration {
                     .securityMatcher("/**")
                     .authorizeHttpRequests(auth -> auth
                             .requestMatchers("/auth/**").permitAll()
+                            .requestMatchers("/admin/**").hasAuthority("ADMIN")
+                            .requestMatchers("/products/**").hasAuthority("USER")
                             .anyRequest().authenticated()
 
 

--- a/src/main/java/com/example/ecommerce/config/auth/AuthenticationService.java
+++ b/src/main/java/com/example/ecommerce/config/auth/AuthenticationService.java
@@ -1,11 +1,10 @@
 package com.example.ecommerce.config.auth;
 
 
-import com.example.ecommerce.controller.AuthenticationRequest;
-import com.example.ecommerce.controller.AuthenticationResponse;
-import com.example.ecommerce.controller.RegisterRequest;
+import com.example.ecommerce.controller.auth.AuthenticationRequest;
+import com.example.ecommerce.controller.auth.AuthenticationResponse;
+import com.example.ecommerce.controller.auth.RegisterRequest;
 import com.example.ecommerce.jwt.JwtService;
-import com.example.ecommerce.model.Role;
 import com.example.ecommerce.model.User;
 import com.example.ecommerce.repository.RoleRepository;
 import com.example.ecommerce.repository.UserRepository;

--- a/src/main/java/com/example/ecommerce/controller/admin/AdminController.java
+++ b/src/main/java/com/example/ecommerce/controller/admin/AdminController.java
@@ -1,0 +1,20 @@
+package com.example.ecommerce.controller.admin;
+
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin")
+public class AdminController {
+
+
+
+    @GetMapping("/dashboard")
+    @PreAuthorize("hasAuthority('ADMIN')")
+    public String getDashboard() {
+        return "Admin dashboard";
+    }
+}

--- a/src/main/java/com/example/ecommerce/controller/auth/AuthController.java
+++ b/src/main/java/com/example/ecommerce/controller/auth/AuthController.java
@@ -1,4 +1,4 @@
-package com.example.ecommerce.controller;
+package com.example.ecommerce.controller.auth;
 
 
 import com.example.ecommerce.config.auth.AuthenticationService;

--- a/src/main/java/com/example/ecommerce/controller/auth/AuthenticationRequest.java
+++ b/src/main/java/com/example/ecommerce/controller/auth/AuthenticationRequest.java
@@ -1,4 +1,4 @@
-package com.example.ecommerce.controller;
+package com.example.ecommerce.controller.auth;
 
 
 import lombok.*;
@@ -8,10 +8,11 @@ import lombok.*;
 @Data
 @Setter
 @Getter
-public class RegisterRequest {
+public class AuthenticationRequest {
 
     private String username;
-    private String email;
     private String password;
+
+
 
 }

--- a/src/main/java/com/example/ecommerce/controller/auth/AuthenticationResponse.java
+++ b/src/main/java/com/example/ecommerce/controller/auth/AuthenticationResponse.java
@@ -1,4 +1,4 @@
-package com.example.ecommerce.controller;
+package com.example.ecommerce.controller.auth;
 
 
 import lombok.*;

--- a/src/main/java/com/example/ecommerce/controller/auth/RegisterRequest.java
+++ b/src/main/java/com/example/ecommerce/controller/auth/RegisterRequest.java
@@ -1,4 +1,4 @@
-package com.example.ecommerce.controller;
+package com.example.ecommerce.controller.auth;
 
 
 import lombok.*;
@@ -8,11 +8,10 @@ import lombok.*;
 @Data
 @Setter
 @Getter
-public class AuthenticationRequest {
+public class RegisterRequest {
 
     private String username;
+    private String email;
     private String password;
-
-
 
 }

--- a/src/main/java/com/example/ecommerce/controller/products/ProductController.java
+++ b/src/main/java/com/example/ecommerce/controller/products/ProductController.java
@@ -1,10 +1,15 @@
 package com.example.ecommerce.controller.products;
 
 
+import com.example.ecommerce.DTO.ProductDTO;
+import com.example.ecommerce.model.Product;
+import com.example.ecommerce.service.products.ProductService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/products")
@@ -12,10 +17,61 @@ public class ProductController {
 
 
 
+    private final ProductService productService;
+
+
+    @Autowired
+    public ProductController(ProductService productService) {
+        this.productService = productService;
+    }
+
+
+
 
     @GetMapping
-    @PreAuthorize("hasAuthority('USER')")
-    public String getProducts() {
-        return "List of products";
+    @PreAuthorize("hasAuthority('USER') or hasAuthority('ADMIN')")
+    public ResponseEntity<List<Product>> getProducts() {
+        List<Product> products = productService.getProducts();
+        return ResponseEntity.ok(products);
+    }
+
+
+    @PostMapping
+    @PreAuthorize("hasAuthority('ADMIN')")
+    public ResponseEntity<Product> createProduct(@RequestBody ProductDTO productDTO) {
+        Product product = Product.builder()
+                .name(productDTO.getName())
+                .price(productDTO.getPrice())
+                .description(productDTO.getDescription())
+                .category(productDTO.getCategory())
+                .image(productDTO.getImg())
+                .build();
+        Product createdProduct = productService.createProduct(product);
+        return ResponseEntity.ok(createdProduct);
+    }
+
+
+    @PutMapping("/{id}")
+    @PreAuthorize("hasAuthority('ADMIN')")
+    public ResponseEntity<Product> updateProduct(
+            @PathVariable Long id,
+            @RequestBody ProductDTO productDTO
+    ) {
+        Product updatedProduct = productService.updateProduct(id, Product.builder()
+                .name(productDTO.getName())
+                .price(productDTO.getPrice())
+                .description(productDTO.getDescription())
+                .category(productDTO.getCategory())
+                .image(productDTO.getImg())
+                .build());
+        return ResponseEntity.ok(updatedProduct);
+    }
+
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasAuthority('ADMIN')")
+    public ResponseEntity<Void> deleteProduct(@PathVariable Long id) {
+        productService.deleteProduct(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/example/ecommerce/controller/products/ProductController.java
+++ b/src/main/java/com/example/ecommerce/controller/products/ProductController.java
@@ -68,6 +68,8 @@ public class ProductController {
     }
 
 
+    //delete
+
     @DeleteMapping("/{id}")
     @PreAuthorize("hasAuthority('ADMIN')")
     public ResponseEntity<Void> deleteProduct(@PathVariable Long id) {

--- a/src/main/java/com/example/ecommerce/controller/products/ProductController.java
+++ b/src/main/java/com/example/ecommerce/controller/products/ProductController.java
@@ -1,0 +1,21 @@
+package com.example.ecommerce.controller.products;
+
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/products")
+public class ProductController {
+
+
+
+
+    @GetMapping
+    @PreAuthorize("hasAuthority('USER')")
+    public String getProducts() {
+        return "List of products";
+    }
+}

--- a/src/main/java/com/example/ecommerce/model/Product.java
+++ b/src/main/java/com/example/ecommerce/model/Product.java
@@ -1,0 +1,36 @@
+package com.example.ecommerce.model;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Product {
+
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Double price;
+
+    @Column(nullable = false)
+    private String description;
+
+
+    @Column(nullable = false)
+    private String category;
+
+    private String image;
+}

--- a/src/main/java/com/example/ecommerce/repository/ProductRepository.java
+++ b/src/main/java/com/example/ecommerce/repository/ProductRepository.java
@@ -1,0 +1,10 @@
+package com.example.ecommerce.repository;
+
+import com.example.ecommerce.model.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface ProductRepository extends JpaRepository<Product, Long> {
+}

--- a/src/main/java/com/example/ecommerce/service/products/ProductService.java
+++ b/src/main/java/com/example/ecommerce/service/products/ProductService.java
@@ -1,0 +1,54 @@
+package com.example.ecommerce.service.products;
+
+
+import com.example.ecommerce.model.Product;
+import com.example.ecommerce.repository.ProductRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class ProductService {
+
+
+    private final ProductRepository productRepository;
+
+    @Autowired
+    public ProductService(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
+
+
+    public List<Product> getProducts() {
+        return productRepository.findAll();
+    }
+
+    public Product createProduct(Product product) {
+        return productRepository.save(product);
+    }
+
+    public Optional<Product> getProductById(Long id) {
+        return productRepository.findById(id);
+    }
+
+
+    public Product updateProduct(Long id, Product product) {
+       return productRepository.findById(id)
+                .map(p -> {
+                    p.setName(product.getName());
+                    p.setPrice(product.getPrice());
+                    p.setDescription(product.getDescription());
+                    p.setCategory(product.getCategory());
+                    p.setImage(product.getImage());
+                    return productRepository.save(p);
+                })
+               .orElseThrow(() -> new RuntimeException("Product not found with id " + id));
+    }
+
+
+    public void deleteProduct(Long id) {
+        productRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
- Add endpoints to manage products:
  - List all products (`GET /products`) accesible by `USER` and `ADMIN`
  - Create a product (`POST /products`) restricted to `ADMIN`
  - Update a product (`PUT /products/{id}`)  restricted to `ADMIN`
  - Delete a product (`DELETE /products/{id}`)  restricted to `ADMIN`
- Integrated ProductDTO for data transfer.
- Apllied role-based secutiry using `@PreAuthorize`
- Fully tested enpoints with JWT tokens in Postman